### PR TITLE
Update credential to aws-sdk v3

### DIFF
--- a/src/Task/ConfigTask.php
+++ b/src/Task/ConfigTask.php
@@ -129,8 +129,10 @@ class ConfigTask extends AbstractTask
         }
 
         if ($this->getKey() && $this->getSecret()) {
-            $config['key'] = $this->getKey();
-            $config['secret'] = $this->getSecret();
+            $config['credentials'] = [
+                'key' => $this->getKey(),
+                'secret' => $this->getSecret(),
+            ];
         } elseif ($this->getProfile()) {
             $config['profile'] = $this->getProfile();
         }


### PR DESCRIPTION
This fix concern the task for create aws configuraiton with `Key` and `Private` variables.

The new versions of `AWS SDK PHP V3` introduce a BC break regarding the credential configuration.

*Fix branche from `0.2.1`*